### PR TITLE
Toggle dark mode on html element

### DIFF
--- a/public/assets/client.js
+++ b/public/assets/client.js
@@ -17,5 +17,5 @@ setInterval(() => {
     }, 500);
 }, 3000);
 document.getElementById("theme-toggle")?.addEventListener("click", () => {
-    document.body.classList.toggle("dark");
+    document.documentElement.classList.toggle("dark");
 });

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -19,5 +19,5 @@ setInterval(() => {
 }, 3000);
 
 document.getElementById("theme-toggle")?.addEventListener("click", () => {
-  document.body.classList.toggle("dark");
+  document.documentElement.classList.toggle("dark");
 });


### PR DESCRIPTION
## Summary
- Toggle dark mode class on document root instead of body
- Rebuild client bundle

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c43f1c2220832893104605481b6c68