### PR TITLE
Specify worker entry in wrangler config

### DIFF
--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -1,0 +1,7 @@
+export default {
+  async fetch(request: Request): Promise<Response> {
+    return new Response("Hello from Worker!", {
+      headers: { "content-type": "text/plain" },
+    });
+  }
+};

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,3 @@
 name = "falconsystems-site"
+main = "src/worker.tsx"
 pages_build_output_dir = "./public"


### PR DESCRIPTION
## Summary
- add `main = "src/worker.tsx"` so wrangler uses the actual Worker entry
- include minimal `src/worker.tsx` stub

## Testing
- `npx tsc src/worker.tsx --noEmit --lib ES2015,DOM`
- `npx wrangler --version`


------
https://chatgpt.com/codex/tasks/task_b_68c4449730ac8328bba8f5fc533f1b8a