### PR TITLE
fix: set worker name and compatibility date

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,3 @@
-name = "falconsystems-site"
+name = "website"
 pages_build_output_dir = "./public"
+compatibility_date = "2025-09-12"


### PR DESCRIPTION
## Summary
- match worker name with repository
- specify `compatibility_date` for Worker uploads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c45d95ab148328b56c7e932514ec32