### PR TITLE
feat: deploy React app via Cloudflare Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "vite dev",
     "build": "vite build",
-    "dev:pages": "wrangler pages dev dist --compatibility-date=2025-09-12",
-    "deploy:pages": "npm run build && wrangler pages deploy dist --project-name falconsystems"
+    "build:watch": "vite build --watch",
+    "dev:worker": "wrangler dev src/worker.tsx --persist",
+    "dev": "npm-run-all -p build:watch dev:worker",
+    "deploy": "npm run build && wrangler deploy src/worker.tsx"
   },
   "dependencies": {
     "hono": "4.9.7",
@@ -21,6 +22,7 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.5.4",
     "vite": "^5.0.0",
-    "wrangler": "^3.57.1"
+    "wrangler": "^3.57.1",
+    "npm-run-all": "^4.1.5"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 
-// Keep ONLY the page body (no <html>, <head>, <body> here)
 export function App() {
   return (
     <>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,7 @@
-name = "falconsystems-pages"
+name = "falconsystems-ssr"
+main = "src/worker.tsx"
 compatibility_date = "2025-09-12"
+
+[assets]
+directory = "dist"
+binding = "ASSETS"


### PR DESCRIPTION
## Summary
- add Cloudflare Worker using Hono to SSR the React app and proxy built assets
- update package scripts and config for Workers deployment, remove Pages Functions

## Testing
- `npm install` (fails: 403 Forbidden fetching packages)
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_b_68c4abf4266c8328abaf31237dac2c76