### PR TITLE
Handle HEAD and OPTIONS requests

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -10,7 +10,27 @@ export default {
       return new Response(indexHTML, { headers: htmlHeaders });
     }
 
-    return new Response('Method Not Allowed', { status: 405 });
+    // Return headers without a body for HEAD requests
+    if (request.method === 'HEAD') {
+      return new Response(null, { headers: htmlHeaders });
+    }
+
+    // Allow preflight/OPTIONS requests without triggering a 405
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        headers: {
+          Allow: 'GET, HEAD, OPTIONS',
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+          'Access-Control-Allow-Headers': '*',
+        },
+      });
+    }
+
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: { Allow: 'GET, HEAD, OPTIONS' },
+    });
   }
 };
 


### PR DESCRIPTION
## Summary
- Serve headers-only responses for HEAD requests
- Respond to OPTIONS preflights and advertise allowed methods
- Include Allow header in 405 responses

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c5688d45348328bf3bd4ed29e75ece