### PR TITLE
Fix logo filename case sensitivity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ export function App() {
     <>
       <header className="p-4">
         <img
-          src="/assets/falcon-logo.png"
+          src="/assets/Falcon-Logo.png"
           alt="Falcon Systems logo"
           className="h-12 w-auto"
         />

--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -8,7 +8,7 @@ export function Html({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Falcon Systems – Teaming with AI</title>
         <link rel="stylesheet" href="/assets/index.css" />
-        <link rel="icon" href="/assets/falcon-logo.png" />
+        <link rel="icon" href="/assets/Falcon-Logo.png" />
       </head>
       <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
         <div id="root">{children}</div>

--- a/worker.js
+++ b/worker.js
@@ -7,7 +7,7 @@ export default {
 
     // Simple router
     if (request.method === 'GET') {
-      if (url.pathname === '/assets/falcon-logo.png') {
+      if (url.pathname === '/assets/Falcon-Logo.png') {
         return new Response(logoPng, { headers: { 'content-type': 'image/png' } });
       }
       return new Response(indexHTML, { headers: htmlHeaders });
@@ -359,7 +359,7 @@ const indexHTML = /* html */ `<!doctype html>
 
 // === Inline SVGs ===
 function logoImage(){
-  return `<img src="/assets/falcon-logo.png" alt="Falcon Systems logo">`;
+  return `<img src="/assets/Falcon-Logo.png" alt="Falcon Systems logo">`;
 }
 function chipIcon(){
   return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- update logo image references to match `/src/assets/Falcon-Logo.png`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: "@vitejs/plugin-react" resolved to an ESM file. ESM file cannot be loaded by `require`)*

------
https://chatgpt.com/codex/tasks/task_b_68c577d05ec08328a320f4e8b3cd7c1c