### PR TITLE
Serve assets through Cloudflare binding

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -7,8 +7,8 @@ export default {
 
     // Simple router
     if (request.method === 'GET') {
-      if (url.pathname === '/assets/Falcon-Logo.png') {
-        return new Response(logoPng, { headers: { 'content-type': 'image/png' } });
+      if (url.pathname.startsWith('/assets/')) {
+        return env.ASSETS.fetch(request);
       }
       return new Response(indexHTML, { headers: htmlHeaders });
     }
@@ -31,9 +31,6 @@ const htmlHeaders = {
   ].join('; '),
   'Cache-Control': 'public, max-age=300',
 };
-
-const logoPngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==";
-const logoPng = Uint8Array.from(atob(logoPngBase64), c => c.charCodeAt(0));
 
 const indexHTML = /* html */ `<!doctype html>
 <html lang="en">

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,10 @@
 name = "falcon-systems-site"
 main = "worker.js"
 compatibility_date = "2025-09-12"
+
+[assets]
+directory = "src/assets"
+binding = "ASSETS"
 # Optional: bind a custom domain after deploying
 # routes = [ { pattern = "falconsystems.ai", custom_domain = true } ]
 


### PR DESCRIPTION
## Summary
- Route `/assets/*` requests through `env.ASSETS` to serve static files
- Configure Wrangler to bundle `src/assets` via the `ASSETS` binding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: ESM plugin '@vitejs/plugin-react' can't be loaded by require)*

------
https://chatgpt.com/codex/tasks/task_b_68c57a0947f883288c44717786a9cbb8