### PR TITLE
Serve built assets with imported logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "falconsystems-pages",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "vite build",
     "build:watch": "vite build --watch",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,11 @@
 import React from "react";
+import logo from "./assets/Falcon-Logo.png";
 
 export function App() {
   return (
     <>
       <header className="p-4">
-        <img
-          src="/assets/Falcon-Logo.png"
-          alt="Falcon Systems logo"
-          className="h-12 w-auto"
-        />
+        <img src={logo} alt="Falcon Systems logo" className="h-12 w-auto" />
       </header>
       {/* Main content */}
       {/* Footer */}

--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from "react";
+import logo from "./assets/Falcon-Logo.png";
 
 export function Html({ children }: PropsWithChildren) {
   return (
@@ -8,7 +9,7 @@ export function Html({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Falcon Systems – Teaming with AI</title>
         <link rel="stylesheet" href="/assets/index.css" />
-        <link rel="icon" href="/assets/Falcon-Logo.png" />
+        <link rel="icon" href={logo} />
       </head>
       <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
         <div id="root">{children}</div>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "worker.js"
 compatibility_date = "2025-09-12"
 
 [assets]
-directory = "src/assets"
+directory = "dist/assets"
 binding = "ASSETS"
 # Optional: bind a custom domain after deploying
 # routes = [ { pattern = "falconsystems.ai", custom_domain = true } ]


### PR DESCRIPTION
## Summary
- Serve compiled assets from `dist/assets` in wrangler config
- Import Falcon logo in React components and use for favicon
- Mark project as ESM for proper Vite build
- Add placeholder file so `dist/assets` exists for Wrangler

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c57c0d8d148328a917eff4eaf18706