### PR TITLE
Add hero section with dark mode and transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "hono": "4.9.7",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "framer-motion": "10.16.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240712.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,61 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { motion } from "framer-motion";
 
 const logo =
   "https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/Falcon-Logo.png";
 
 export function App() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+  }, [dark]);
+
   return (
-    <>
-      <header className="p-4">
-        <img src={logo} alt="Falcon Systems logo" className="h-12 w-auto" />
+    <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
+      <header className="p-4 flex justify-between items-center">
+        <img
+          src={logo}
+          alt="Falcon Systems logo"
+          className="h-12 w-auto transition-transform duration-250 hover:scale-110"
+        />
+        <button
+          onClick={() => setDark(!dark)}
+          className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-250 hover:bg-gray-300 dark:hover:bg-gray-600"
+        >
+          {dark ? "Light Mode" : "Dark Mode"}
+        </button>
       </header>
-      {/* Main content */}
-      {/* Footer */}
-      <footer className="p-4 text-center">
+
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-col items-center text-center py-20 bg-gradient-to-r from-purple-500 to-pink-500 dark:from-gray-800 dark:to-gray-900"
+      >
+        <h1 className="text-4xl font-bold mb-4">Welcome to Falcon Systems</h1>
+        <p className="mb-8 text-lg">Innovative solutions for a digital world.</p>
+        <a
+          href="#get-started"
+          className="px-6 py-3 bg-white text-purple-600 rounded-md font-semibold shadow transition-transform duration-250 hover:scale-105"
+        >
+          Get Started
+        </a>
+      </motion.section>
+
+      <footer className="p-4 text-center mt-auto">
         <a
           href="mailto:info@falconsystems.ai"
-          className="text-blue-600 hover:underline"
+          className="text-blue-600 dark:text-blue-400 transition-colors duration-250 hover:text-blue-800 dark:hover:text-blue-200"
         >
           info@falconsystems.ai
         </a>
       </footer>
-    </>
+    </div>
   );
 }
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,13 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./src/**/*.{ts,tsx}", "./index.html"],
   theme: {
-    extend: {},
+    extend: {
+      transitionDuration: {
+        250: "250ms",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add framer-motion hero section with call-to-action
- implement dark mode toggle and styling
- enhance header logo and footer link with hover transitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "framer-motion")*

------
https://chatgpt.com/codex/tasks/task_b_68c58de304e88328b6fae230e43b838e