### PR TITLE
Ensure favicon uses logo and centralize asset

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-
-const logo =
-  "https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/Falcon-Logo.png";
+import { logo } from "./logo";
 
 export function App() {
   const [dark, setDark] = useState(false);

--- a/src/logo.ts
+++ b/src/logo.ts
@@ -1,0 +1,1 @@
+export const logo = "https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/Falcon-Logo.png";

--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -1,7 +1,5 @@
 import React, { PropsWithChildren } from "react";
-
-const logo =
-  "https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/Falcon-Logo.png";
+import { logo } from "./logo";
 
 export function Html({ children }: PropsWithChildren) {
   return (
@@ -11,7 +9,7 @@ export function Html({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Falcon Systems – Teaming with AI</title>
         <link rel="stylesheet" href="/assets/index.css" />
-        <link rel="icon" href={logo} />
+        <link rel="icon" type="image/png" href={logo} />
       </head>
       <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
         <div id="root">{children}</div>


### PR DESCRIPTION
## Summary
- centralize logo URL and reuse across components
- set favicon with explicit PNG type

## Testing
- `npm run build` *(fails: Rollup failed to resolve import "framer-motion")*


------
https://chatgpt.com/codex/tasks/task_b_68c592d6cf1c8328a12d11c1b3a0469c