### PR TITLE
Fix transition durations and wire contact form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,11 +20,11 @@ export function App() {
         <img
           src={logo}
           alt="Falcon Systems logo"
-          className="h-12 w-auto transition-transform duration-250 hover:scale-110"
+          className="h-12 w-auto transition-transform duration-300 hover:scale-110"
         />
         <button
           onClick={() => setDark(!dark)}
-          className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-250 hover:bg-gray-300 dark:hover:bg-gray-600"
+          className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-300 hover:bg-gray-300 dark:hover:bg-gray-600"
         >
           {dark ? "Light Mode" : "Dark Mode"}
         </button>
@@ -39,7 +39,7 @@ export function App() {
         <p className="mb-8 text-lg">Innovative solutions for a digital world.</p>
         <a
           href="#get-started"
-          className="px-6 py-3 bg-white text-purple-600 rounded-md font-semibold shadow transition-transform duration-250 hover:scale-105"
+          className="px-6 py-3 bg-white text-purple-600 rounded-md font-semibold shadow transition-transform duration-300 hover:scale-105"
         >
           Get Started
         </a>
@@ -48,7 +48,7 @@ export function App() {
       <footer className="p-4 text-center mt-auto">
         <a
           href="mailto:info@falconsystems.ai"
-          className="text-blue-600 dark:text-blue-400 transition-colors duration-250 hover:text-blue-800 dark:hover:text-blue-200"
+          className="text-blue-600 dark:text-blue-400 transition-colors duration-300 hover:text-blue-800 dark:hover:text-blue-200"
         >
           info@falconsystems.ai
         </a>

--- a/worker.js
+++ b/worker.js
@@ -279,7 +279,7 @@ const indexHTML = /* html */ `<!doctype html>
             <input aria-label="Email" type="email" name="email" placeholder="you@company.com" required />
             <button type="submit">Notify me</button>
           </div>
-          <small id="lead-msg" class="small" style="display:block; margin-top:6px; opacity:.85;"></small>
+          <small class="small" style="display:block; margin-top:6px; opacity:.85;">We'll open your email client to send us a message.</small>
         </form>
       </div>
     </section>
@@ -340,16 +340,12 @@ const indexHTML = /* html */ `<!doctype html>
     addEventListener('resize', resize); resize(); draw();
 
     // Email capture placeholder — replace with your backend/Forms later
-    async function submitLead(e){
+    function submitLead(e){
       e.preventDefault();
-      const msg = document.getElementById('lead-msg');
       const email = new FormData(e.target).get('email');
-      // No backend wired yet, so we just fake success and provide a handoff instruction.
-      await new Promise(r=>setTimeout(r, 500));
-        // Avoid nested template literals so this string is preserved correctly
-        // when the outer HTML template is evaluated.
-        msg.textContent = 'Thanks! We\'ll reach out at ' +
-          email + '. (Hook this form to your CRM or a Worker KV/D1 endpoint.)';
+      const subject = encodeURIComponent('Falcon Systems Contact');
+      const body = encodeURIComponent('Please follow up with ' + email + '.');
+      window.location.href = 'mailto:info@falconsystems.ai?subject=' + subject + '&body=' + body;
     }
 
     // Year


### PR DESCRIPTION
## Summary
- use standard Tailwind transition durations to enable animations
- hook contact form to open info@falconsystems.ai via mailto link

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: Rollup failed to resolve import "framer-motion")

------
https://chatgpt.com/codex/tasks/task_b_68c594aede308328a5f2b50668856e44