### PR TITLE
Normalize LeapsPicker routing to handle trailing slashes

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -2,14 +2,15 @@ import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import { App } from "./App";
 import { LeapsPicker } from "./LeapsPicker";
+import { normalizePath } from "./utils";
 import "./index.css";
 
 function boot() {
   try {
     const el = document.getElementById("root");
     if (!el) throw new Error("#root not found");
-    const pathname = window.location.pathname;
-    const Page = pathname === "/leapspicker" ? LeapsPicker : App;
+    const path = normalizePath(window.location.pathname);
+    const Page = path === "/leapspicker" ? LeapsPicker : App;
     hydrateRoot(el, <Page />);
   } catch (e) {
     console.error("Hydration failed:", e);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+export function normalizePath(path: string): string {
+  if (path.length > 1 && path.endsWith("/")) {
+    return path.slice(0, -1);
+  }
+  return path || "/";
+}

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -4,6 +4,7 @@ import { renderToReadableStream } from "react-dom/server";
 import { Html } from "./shell";
 import { App } from "./App";
 import { LeapsPicker } from "./LeapsPicker";
+import { normalizePath } from "./utils";
 
 type Env = { ASSETS: Fetcher };
 
@@ -19,7 +20,8 @@ app.get("/assets/*", (c) => c.env.ASSETS.fetch(c.req.raw));
 app.get("*", async (c) => {
   try {
     const url = new URL(c.req.url);
-    const page = url.pathname === "/leapspicker" ? <LeapsPicker /> : <App />;
+    const path = normalizePath(url.pathname);
+    const page = path === "/leapspicker" ? <LeapsPicker /> : <App />;
     const stream: any = await renderToReadableStream(<Html>{page}</Html>, {
       onError(err) {
         console.error("SSR error:", err);


### PR DESCRIPTION
## Summary
- normalize URL paths to strip trailing slashes
- use normalized paths for routing in worker and client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build -- --outDir=dist-temp`


------
https://chatgpt.com/codex/tasks/task_b_68c5af6dfb3c8328986286dac3793ed1