### PR TITLE
Embed LEAPS Picker content on home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,19 @@
 import React, { useEffect, useState } from "react";
 import { logo } from "./logo";
+import { LeapsPicker } from "./LeapsPicker";
 
 export function App() {
   const [dark, setDark] = useState(false);
+
+  const handleLeadSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const email = new FormData(e.currentTarget).get("email");
+    if (typeof email === "string") {
+      const subject = encodeURIComponent("Falcon Systems Contact");
+      const body = encodeURIComponent(`Please follow up with ${email}.`);
+      window.location.href = `mailto:info@falconsystems.ai?subject=${subject}&body=${body}`;
+    }
+  };
 
   useEffect(() => {
     const root = document.documentElement;
@@ -22,12 +33,6 @@ export function App() {
           className="h-12 w-auto transition-transform duration-300 hover:scale-110"
         />
         <nav className="flex items-center space-x-4">
-          <a
-            href="/leapspicker"
-            className="text-blue-600 dark:text-blue-400 transition-colors duration-300 hover:text-blue-800 dark:hover:text-blue-200"
-          >
-            LEAPS Picker
-          </a>
           <button
             onClick={() => setDark(!dark)}
             className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-300 hover:bg-gray-300 dark:hover:bg-gray-600"
@@ -48,6 +53,66 @@ export function App() {
         >
           Get Started
         </a>
+      </section>
+
+      <section
+        id="how"
+        className="py-20 bg-gray-100 dark:bg-gray-800 text-center"
+      >
+        <h2 className="text-3xl font-bold mb-6">How it Works</h2>
+        <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">
+          <div>
+            <h3 className="font-semibold mb-2">1) Discovery</h3>
+            <p>
+              Identify high-leverage use cases, guardrails, and success
+              criteria.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">2) Pilot</h3>
+            <p>
+              Hands-on cohort training in our sandbox. Instrumentation from day
+              one.
+            </p>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">3) Rollout</h3>
+            <p>
+              Codify patterns into repeatable workflows with governance
+              built-in.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <LeapsPicker />
+
+      <section
+        id="contact"
+        className="py-20 bg-white dark:bg-gray-900 text-center"
+      >
+        <h2 className="text-3xl font-bold mb-4">Ready to see it in action?</h2>
+        <p className="mb-6">
+          Book a demo or join our update list—no spam, just practical insights.
+        </p>
+        <form
+          onSubmit={handleLeadSubmit}
+          className="max-w-md mx-auto flex flex-col sm:flex-row gap-4"
+        >
+          <input
+            type="email"
+            name="email"
+            required
+            placeholder="you@company.com"
+            className="flex-1 p-3 border rounded"
+          />
+          <button
+            type="submit"
+            className="px-6 py-3 bg-blue-600 text-white rounded"
+          >
+            Notify me
+          </button>
+        </form>
       </section>
 
       <footer className="p-4 text-center mt-auto">

--- a/src/LeapsPicker.tsx
+++ b/src/LeapsPicker.tsx
@@ -2,30 +2,18 @@ import React from "react";
 
 export function LeapsPicker() {
   return (
-    <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <header className="p-4">
-        <a href="/" className="text-blue-600 dark:text-blue-400 hover:underline">&larr; Back to Home</a>
-      </header>
-      <main className="flex flex-col items-center p-4">
-        <h1 className="text-4xl font-bold mb-4">LEAPS Picker</h1>
-        <p className="mb-6 max-w-2xl text-center">
+    <section id="leapspicker" className="py-20 bg-gray-50 dark:bg-gray-800">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <h2 className="text-3xl font-bold mb-4">LEAPS Picker</h2>
+        <p className="mb-6">
           A custom fintech webapp showcasing backend AI integration to streamline long-term equity options strategies.
         </p>
         <img
           src="https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/leapspicker.png"
           alt="LEAPS Picker screenshot"
-          className="max-w-full rounded shadow-lg"
+          className="max-w-full rounded shadow-lg mx-auto"
         />
-      </main>
-      <footer className="p-4 text-center mt-auto">
-        <a
-          href="mailto:info@falconsystems.ai"
-          className="text-blue-600 dark:text-blue-400 transition-colors duration-300 hover:text-blue-800 dark:hover:text-blue-200"
-        >
-          info@falconsystems.ai
-        </a>
-      </footer>
-    </div>
+      </div>
+    </section>
   );
 }
-

--- a/src/worker.tsx
+++ b/src/worker.tsx
@@ -3,8 +3,6 @@ import React from "react";
 import { renderToReadableStream } from "react-dom/server";
 import { Html } from "./shell";
 import { App } from "./App";
-import { LeapsPicker } from "./LeapsPicker";
-import { normalizePath } from "./utils";
 
 type Env = { ASSETS: Fetcher };
 
@@ -19,9 +17,7 @@ app.get("/assets/*", (c) => c.env.ASSETS.fetch(c.req.raw));
 // SSR catch-all
 app.get("*", async (c) => {
   try {
-    const url = new URL(c.req.url);
-    const path = normalizePath(url.pathname);
-    const page = path === "/leapspicker" ? <LeapsPicker /> : <App />;
+    const page = <App />;
     const stream: any = await renderToReadableStream(<Html>{page}</Html>, {
       onError(err) {
         console.error("SSR error:", err);


### PR DESCRIPTION
## Summary
- Inline LEAPS Picker showcase within the main page
- Add "How it Works" and contact sections to home
- Simplify worker routing to always render the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5b1ccc114832885ab3d1b50f2b07b