### PR TITLE
Set Falcon logo as favicon

### DIFF
--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -1,5 +1,4 @@
 import React, { PropsWithChildren } from "react";
-import { logo } from "./logo";
 
 export function Html({ children }: PropsWithChildren) {
   return (
@@ -9,7 +8,7 @@ export function Html({ children }: PropsWithChildren) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Falcon Systems – Teaming with AI</title>
         <link rel="stylesheet" href="/assets/index.css" />
-        <link rel="icon" type="image/png" href={logo} />
+        <link rel="icon" type="image/png" href="/dist/assets/Falcon-Logo.png" />
       </head>
       <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
         <div id="root">{children}</div>

--- a/worker.js
+++ b/worker.js
@@ -48,6 +48,7 @@ const indexHTML = /* html */ `<!doctype html>
   <meta property="og:description" content="Curriculum, teachings, and a managed sandbox to help teams leverage AI safely and effectively." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="data:image/svg+xml,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScxMjAwJyBoZWlnaHQ9JzYzMCc+PHJlY3Qgd2lkdGg9JzEyMDAnIGhlaWdodD0nNjMwJyBmaWxsPSIjMDBhNWZkIi8+PC9zdmc+" />
+  <link rel="icon" href="/dist/assets/Falcon-Logo.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- reference Falcon logo file for browser favicon in HTML shell
- embed favicon link in Cloudflare worker index

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5be04be788328b89da0ce3a0eaeab