### PR TITLE
feat: add hero text scramble effect

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -357,38 +357,78 @@ const indexHTML = /* html */ `<!doctype html>
       window.location.href = 'mailto:info@falconsystems.ai?subject=' + subject + '&body=' + body;
     }
 
-    // Typewriter effect for hero title
+    // Text scramble effect for hero title
     const heroTitle = document.getElementById('hero-title');
     const segments = [
       { text: 'Your ' },
       { text: 'operating layer', class: 'gradient-text' },
       { text: ' for AI-driven work' }
     ];
-    function typeSegments(el, segs, delay){
-      let p = Promise.resolve();
-      for (const seg of segs){
-        p = p.then(function(){
-          const target = seg.class ? (function(){
-            const s = document.createElement('span');
-            s.className = seg.class;
-            el.appendChild(s);
-            return s;
-          })() : el;
-          return new Promise(function(res){
-            let i = 0;
-            (function type(){
-              if (i < seg.text.length){
-                target.textContent += seg.text[i++];
-                setTimeout(type, delay);
-              } else {
-                res();
-              }
-            })();
-          });
-        });
+
+    class TextScramble {
+      constructor(el){
+        this.el = el;
+        this.chars = '!<>-_\\/[]{}—=+*^?#________';
+        this.update = this.update.bind(this);
+      }
+      setText(newText){
+        const oldText = this.el.textContent;
+        const length = Math.max(oldText.length, newText.length);
+        const promise = new Promise(resolve => this.resolve = resolve);
+        this.queue = [];
+        for (let i = 0; i < length; i++){
+          const from = oldText[i] || '';
+          const to = newText[i] || '';
+          const start = Math.floor(Math.random() * 40);
+          const end = start + Math.floor(Math.random() * 40);
+          this.queue.push({ from, to, start, end, char: '' });
+        }
+        cancelAnimationFrame(this.frameRequest);
+        this.frame = 0;
+        this.update();
+        return promise;
+      }
+      update(){
+        let output = '';
+        let complete = 0;
+        for (let i = 0, n = this.queue.length; i < n; i++){
+          let { from, to, start, end, char } = this.queue[i];
+          if (this.frame >= end){
+            complete++;
+            output += to;
+          } else if (this.frame >= start){
+            if (!char || Math.random() < 0.28){
+              char = this.randomChar();
+              this.queue[i].char = char;
+            }
+            output += char;
+          } else {
+            output += from;
+          }
+        }
+        this.el.textContent = output;
+        if (complete === this.queue.length){
+          this.resolve();
+        } else {
+          this.frameRequest = requestAnimationFrame(this.update);
+          this.frame++;
+        }
+      }
+      randomChar(){
+        return this.chars[Math.floor(Math.random() * this.chars.length)];
       }
     }
-    typeSegments(heroTitle, segments, 50);
+
+    const scramble = new TextScramble(heroTitle);
+    scramble.setText(segments.map(s => s.text).join('')).then(() => {
+      heroTitle.textContent = '';
+      segments.forEach(seg => {
+        const span = document.createElement('span');
+        if (seg.class) span.className = seg.class;
+        span.textContent = seg.text;
+        heroTitle.appendChild(span);
+      });
+    });
 
     // Year
     document.getElementById('year').textContent = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- replace hero typewriter animation with text scramble effect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c5cc257c448328b0159ecfe53854b7