### PR TITLE
Simplify /tempovore page to render single hosted image

### DIFF
--- a/src/TempovorePage.tsx
+++ b/src/TempovorePage.tsx
@@ -1,26 +1,13 @@
 import React from "react";
-import tempovoreLogo from "./assets/tempovore-logo.svg";
 
 export function TempovorePage() {
   return (
-    <main className="min-h-screen bg-[#120f0f] text-[#f2d28d] flex items-center justify-center px-6 py-12">
-      <section className="w-full max-w-5xl text-center">
-        <p className="uppercase tracking-[0.4em] text-sm md:text-base mb-5 opacity-80">
-          Falcon Systems Presents
-        </p>
-
-        <h1 className="text-4xl md:text-6xl font-semibold mb-6">TempΘvore</h1>
-
-        <img
-          src={tempovoreLogo}
-          alt="Tempovore band logo"
-          className="w-full max-w-4xl mx-auto rounded-xl shadow-[0_20px_60px_rgba(0,0,0,0.55)] border border-[#c79f5d]/30"
-        />
-
-        <p className="mt-8 text-lg md:text-2xl text-[#f5dfad]">
-          Progressive metal. Cinematic depth. Unrelenting pulse.
-        </p>
-      </section>
+    <main className="min-h-screen bg-black flex items-center justify-center">
+      <img
+        src="https://falconsystems.ai/tempovore.png"
+        alt="Tempovore"
+        className="max-w-full max-h-screen object-contain"
+      />
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Replace the previous Tempovore marketing layout with a minimal page that directly displays the hosted image for the `/tempovore` route.

### Description
- Updated `src/TempovorePage.tsx` to remove the previous title, copy, and local SVG import and to render a single `img` with `src="https://falconsystems.ai/tempovore.png"` centered in the viewport.
- Simplified layout classes so the image is constrained to the viewport using `max-w-full` and `max-h-screen` and `object-contain`.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dbe5eca96c8328a98ed52904189bb7)