### PR TITLE
Style Tempovore page with polished image-focused layout

### DIFF
--- a/src/TempovorePage.tsx
+++ b/src/TempovorePage.tsx
@@ -1,13 +1,26 @@
 import React from "react";
 
+const imageUrl =
+  "https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/tempovore.png";
+
 export function TempovorePage() {
   return (
-    <main className="min-h-screen bg-black flex items-center justify-center">
-      <img
-        src="https://pub-d19e7dbfe91f43cf8b5602b495c5de08.r2.dev/tempovore.png"
-        alt="Tempovore"
-        className="max-w-full max-h-screen object-contain"
-      />
+    <main className="relative min-h-screen overflow-hidden bg-[#030303] text-white">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-20 top-[-15%] h-80 w-80 rounded-full bg-fuchsia-500/20 blur-3xl" />
+        <div className="absolute -right-24 bottom-[-10%] h-96 w-96 rounded-full bg-cyan-400/20 blur-3xl" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(255,255,255,0.08),transparent_45%)]" />
+      </div>
+
+      <section className="relative z-10 flex min-h-screen items-center justify-center px-4 py-8 sm:px-8">
+        <figure className="relative w-full max-w-6xl rounded-2xl border border-white/10 bg-black/35 p-2 shadow-[0_0_90px_rgba(236,72,153,0.14)] backdrop-blur-sm sm:p-4">
+          <img
+            src={imageUrl}
+            alt="Tempovore"
+            className="mx-auto max-h-[85vh] w-full rounded-xl object-contain"
+          />
+        </figure>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Present the Tempovore artwork as the sole page content while making the page feel finished and visually polished.
- Add subtle visual depth and a restrained frame so the image reads as a centerpiece without introducing navigation or additional UI yet.

### Description
- Reworked `src/TempovorePage.tsx` to replace the bare image with a full-screen layout that centers the artwork in a composed scene.
- Added an `imageUrl` constant and ambient glow layers (fuchsia and cyan blurred circles) plus a radial highlight overlay to give depth without distracting from the image.
- Wrapped the image in a centered figure with rounded corners, a soft translucent border, a backdrop blur, and a shadow to create a glass-like frame while constraining `max-height` for viewport fit.
- Styling is implemented via Tailwind utility classes and no other files were modified.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dce12d123c832893955cc9636ec27d)