### PR TITLE
Fix Tempovore page stylesheet link

### DIFF
--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -7,7 +7,7 @@ export function Html({ children }: PropsWithChildren) {
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Falcon Systems – Teaming with AI</title>
-        <link rel="stylesheet" href="/assets/index.css" />
+        <link rel="stylesheet" href="/assets/client.css" />
         <link rel="icon" type="image/png" href="/dist/assets/Falcon-Logo.png" />
       </head>
       <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">


### PR DESCRIPTION
### Motivation
- The Tempovore route was rendering without Tailwind styles because the server-rendered HTML shell referenced `/assets/index.css` while the Vite build outputs `/assets/client.css`, resulting in an image-only appearance.

### Description
- Updated `src/shell.tsx` to load `/assets/client.css` instead of `/assets/index.css` in the `Html` component so SSR pages (like `/tempovore`) receive the correct stylesheet.

### Testing
- Ran `npm run build` which completed successfully and produced the expected `dist/assets/client.css` and `dist/assets/client.js` artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69deac1df6408328b88c88e0027ad279)