### PR TITLE
Remove special /tempovore handling from Cloudflare worker

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -15,9 +15,6 @@ export default {
       if (url.pathname.startsWith('/assets/')) {
         return env.ASSETS.fetch(request);
       }
-      if (url.pathname === '/tempovore' || url.pathname === '/tempovore/') {
-        return new Response(tempovoreHTML, { headers: htmlHeaders });
-      }
       return new Response(indexHTML, { headers: htmlHeaders });
     }
 
@@ -39,59 +36,6 @@ const htmlHeaders = {
   ].join('; '),
   'Cache-Control': 'public, max-age=300',
 };
-
-
-const tempovoreHTML = /* html */ `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>TempΘvore | Falcon Systems</title>
-  <meta name="description" content="TempΘvore band page" />
-  <style>
-    :root { color-scheme: dark; }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      display: grid;
-      place-items: center;
-      padding: 24px;
-      font-family: Georgia, 'Times New Roman', serif;
-      background: radial-gradient(circle at 20% 20%, #27201a, #120f0f 65%);
-      color: #f2d28d;
-    }
-    main {
-      width: min(1080px, 100%);
-      text-align: center;
-    }
-    h1 {
-      letter-spacing: 0.08em;
-      margin: 0 0 20px;
-      font-size: clamp(2rem, 6vw, 4.8rem);
-    }
-    .logo {
-      width: min(100%, 920px);
-      border-radius: 16px;
-      border: 1px solid rgba(242, 210, 141, 0.35);
-      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.55);
-    }
-    p {
-      margin-top: 24px;
-      font-family: Inter, system-ui, -apple-system, Segoe UI, sans-serif;
-      letter-spacing: 0.02em;
-      color: #f8e6bf;
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <h1>TempΘvore</h1>
-    <img class="logo" src="/assets/tempovore-logo.svg" alt="Tempovore band logo" />
-    <p>Progressive metal • cinematic depth • unrelenting pulse</p>
-  </main>
-</body>
-</html>`;
 
 const indexHTML = /* html */ `<!doctype html>
 <html lang="en">
@@ -423,5 +367,4 @@ const indexHTML = /* html */ `<!doctype html>
       const body = encodeURIComponent('Please follow up with ' + email + '.');
       window.location.href = 'mailto:info@falconsystems.ai?subject=' + subject + '&body=' + body;
     }
-
 


### PR DESCRIPTION
### Motivation
- The site has a React/Tailwind `TempovorePage` rendered by `src/routes.tsx`, so `/tempovore` should be handled by the main app router rather than a separate static response in the worker.
- Remove duplicate/hardcoded page so the client app can render the canonical Tempovore UI and share assets/CSP/logic consistently.

### Description
- Removed the dedicated `/tempovore` route branch from `worker.js` so non-asset GET requests now fall through to the standard `indexHTML` response instead of returning a special page.
- Deleted the inline `tempovoreHTML` constant from `worker.js` (the hardcoded Tempovore HTML is removed).
- Kept asset handling intact (`/assets/*` still proxied to `env.ASSETS`) and left `indexHTML` as the single page payload returned by the worker.

### Testing
- Ran `npm run build` (Vite build) which completed successfully and produced `dist/assets/client.css` and `dist/assets/client.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69deae9488248328a65b3939d5d4f738)