### PR TITLE
Refactor landing to AI deal-intel layout, remove legacy picker and routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,131 +1,167 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { logo } from "./logo";
-import { LeapsPicker } from "./LeapsPicker";
+
+const dealSignals = [
+  "County foreclosure auction calendars",
+  "Bank REO feeds and distressed listing tags",
+  "Lis pendens and notice-of-default filings",
+  "Rent rolls, cap rate comps, and neighborhood trend deltas",
+];
+
+const userOutputs = [
+  "Deal score (0-100) based on margin, risk, and velocity",
+  "12-month upside/downside cash-flow scenarios",
+  "Neighborhood and asset-level risk flags",
+  "Action checklist for underwriting, outreach, and due diligence",
+];
+
+const pageStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  background: "#020617",
+  color: "#e2e8f0",
+  fontFamily: "Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif",
+};
+
+const containerStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "1120px",
+  margin: "0 auto",
+  padding: "0 24px",
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "rgba(255,255,255,0.04)",
+  border: "1px solid rgba(148,163,184,0.25)",
+  borderRadius: "16px",
+  padding: "24px",
+};
 
 export function App() {
-  const [dark, setDark] = useState(false);
-
-  const handleLeadSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const email = new FormData(e.currentTarget).get("email");
-    if (typeof email === "string") {
-      const subject = encodeURIComponent("Falcon Systems Contact");
-      const body = encodeURIComponent(`Please follow up with ${email}.`);
-      window.location.href = `mailto:info@falconsystems.ai?subject=${subject}&body=${body}`;
-    }
-  };
-
-  useEffect(() => {
-    const root = document.documentElement;
-    if (dark) {
-      root.classList.add("dark");
-    } else {
-      root.classList.remove("dark");
-    }
-  }, [dark]);
-
   return (
-    <div className="min-h-screen flex flex-col bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
-      <header className="p-4 flex justify-between items-center">
-        <img
-          src={logo}
-          alt="Falcon Systems logo"
-          className="h-12 w-auto transition-transform duration-300 hover:scale-110"
-        />
-        <nav className="flex items-center space-x-4">
-          <button
-            onClick={() => setDark(!dark)}
-            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-300 hover:bg-gray-300 dark:hover:bg-gray-600"
+    <main style={pageStyle}>
+      <header
+        style={{ borderBottom: "1px solid rgba(148,163,184,0.2)", background: "#020617" }}
+      >
+        <div
+          style={{
+            ...containerStyle,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingTop: "20px",
+            paddingBottom: "20px",
+            gap: "16px",
+          }}
+        >
+          <img src={logo} alt="Falcon logo" style={{ height: "48px", width: "auto" }} />
+          <span
+            style={{
+              border: "1px solid rgba(34,211,238,0.5)",
+              borderRadius: "999px",
+              padding: "6px 14px",
+              fontSize: "12px",
+              fontWeight: 700,
+              letterSpacing: "0.16em",
+              textTransform: "uppercase",
+              color: "#67e8f9",
+              background: "rgba(34,211,238,0.08)",
+            }}
           >
-            {dark ? "Light Mode" : "Dark Mode"}
-          </button>
-        </nav>
+            AI Deal Intelligence
+          </span>
+        </div>
       </header>
 
-      <section
-        className="flex flex-col items-center text-center py-20 bg-gradient-to-r from-purple-500 to-pink-500 dark:from-gray-800 dark:to-gray-900"
-      >
-        <h1 className="text-4xl font-bold mb-4 gradient-text">
-          Welcome to Falcon Systems
+      <section style={{ ...containerStyle, paddingTop: "72px", paddingBottom: "42px" }}>
+        <p style={{ margin: 0, color: "#67e8f9", fontWeight: 700, letterSpacing: "0.18em", textTransform: "uppercase", fontSize: "12px" }}>
+          Falcon Systems
+        </p>
+        <h1 style={{ fontSize: "clamp(2.1rem, 5vw, 3.8rem)", lineHeight: 1.12, margin: "16px 0 0", color: "#fff" }}>
+          Real estate deals surfaced by autonomous AI agents.
         </h1>
-        <p className="mb-8 text-lg">Innovative solutions for a digital world.</p>
-        <a
-          href="#get-started"
-          className="px-6 py-3 bg-white text-purple-600 rounded-md font-semibold shadow transition-transform duration-300 hover:scale-105"
-        >
-          Get Started
-        </a>
+        <p style={{ marginTop: "22px", maxWidth: "760px", color: "#cbd5e1", fontSize: "1.15rem", lineHeight: 1.6 }}>
+          We rebuilt Falcon around one mission: continuously scan foreclosure and pre-foreclosure multifamily opportunities,
+          then publish clear, investor-ready analysis to this platform.
+        </p>
       </section>
 
       <section
-        id="how"
-        className="py-20 bg-gray-100 dark:bg-gray-800 text-center"
+        style={{
+          ...containerStyle,
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: "20px",
+          paddingBottom: "26px",
+        }}
       >
-        <h2 className="text-3xl font-bold mb-6">How it Works</h2>
-        <div className="max-w-4xl mx-auto grid md:grid-cols-3 gap-8">
-          <div>
-            <h3 className="font-semibold mb-2">1) Discovery</h3>
-            <p>
-              Identify high-leverage use cases, guardrails, and success
-              criteria.
-            </p>
+        <article style={cardStyle}>
+          <h2 style={{ margin: "0 0 12px", color: "#fff", fontSize: "1.5rem" }}>What our agents monitor</h2>
+          <ul style={{ margin: 0, paddingLeft: "20px", color: "#cbd5e1", lineHeight: 1.7 }}>
+            {dealSignals.map((signal) => (
+              <li key={signal}>{signal}</li>
+            ))}
+          </ul>
+        </article>
+
+        <article style={cardStyle}>
+          <h2 style={{ margin: "0 0 12px", color: "#fff", fontSize: "1.5rem" }}>What users receive</h2>
+          <ul style={{ margin: 0, paddingLeft: "20px", color: "#cbd5e1", lineHeight: 1.7 }}>
+            {userOutputs.map((output) => (
+              <li key={output}>{output}</li>
+            ))}
+          </ul>
+        </article>
+      </section>
+
+      <section style={{ ...containerStyle, paddingTop: "10px", paddingBottom: "20px" }}>
+        <article
+          style={{
+            ...cardStyle,
+            border: "1px solid rgba(34,211,238,0.45)",
+            background: "rgba(15,23,42,0.9)",
+          }}
+        >
+          <h2 style={{ marginTop: 0, marginBottom: "18px", color: "#fff", fontSize: "1.5rem" }}>Live analysis format</h2>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: "12px", color: "#cbd5e1", lineHeight: 1.6 }}>
+            <p style={{ margin: 0 }}><strong style={{ color: "#fff" }}>Asset:</strong> 42-unit multifamily, Sun Belt secondary market.</p>
+            <p style={{ margin: 0 }}><strong style={{ color: "#fff" }}>Status:</strong> Pre-foreclosure, notice filed within the last 14 days.</p>
+            <p style={{ margin: 0 }}><strong style={{ color: "#fff" }}>Projected entry discount:</strong> 18% below trailing market comps.</p>
+            <p style={{ margin: 0 }}><strong style={{ color: "#fff" }}>AI conviction:</strong> 87/100 with moderate renovation risk.</p>
           </div>
-          <div>
-            <h3 className="font-semibold mb-2">2) Pilot</h3>
-            <p>
-              Hands-on cohort training in our sandbox. Instrumentation from day
-              one.
-            </p>
-          </div>
-          <div>
-            <h3 className="font-semibold mb-2">3) Rollout</h3>
-            <p>
-              Codify patterns into repeatable workflows with governance
-              built-in.
-            </p>
-          </div>
+        </article>
+      </section>
+
+      <section style={{ ...containerStyle, paddingTop: "18px", paddingBottom: "72px" }}>
+        <div
+          style={{
+            borderRadius: "16px",
+            border: "1px solid rgba(148,163,184,0.3)",
+            padding: "28px",
+            background: "linear-gradient(90deg, rgba(34,211,238,0.1), rgba(59,130,246,0.09), rgba(99,102,241,0.09))",
+          }}
+        >
+          <h2 style={{ margin: 0, color: "#fff", fontSize: "clamp(1.5rem, 3vw, 2rem)" }}>Built for investors who move fast.</h2>
+          <p style={{ margin: "14px 0 0", color: "#cbd5e1", maxWidth: "760px", lineHeight: 1.65 }}>
+            Falcon agents collect, rank, and explain multifamily distress opportunities so your team can spend time making
+            offers—not hunting fragmented data.
+          </p>
+          <a
+            href="mailto:info@falconsystems.ai?subject=Falcon%20Deal%20Intelligence"
+            style={{
+              display: "inline-block",
+              marginTop: "20px",
+              borderRadius: "10px",
+              background: "#67e8f9",
+              color: "#0f172a",
+              padding: "12px 20px",
+              fontWeight: 700,
+              textDecoration: "none",
+            }}
+          >
+            Request Early Access
+          </a>
         </div>
       </section>
-
-      <LeapsPicker />
-
-      <section
-        id="contact"
-        className="py-20 bg-white dark:bg-gray-900 text-center"
-      >
-        <h2 className="text-3xl font-bold mb-4">Ready to see it in action?</h2>
-        <p className="mb-6">
-          Book a demo or join our update list—no spam, just practical insights.
-        </p>
-        <form
-          onSubmit={handleLeadSubmit}
-          className="max-w-md mx-auto flex flex-col sm:flex-row gap-4"
-        >
-          <input
-            type="email"
-            name="email"
-            required
-            placeholder="you@company.com"
-            className="flex-1 p-3 border rounded"
-          />
-          <button
-            type="submit"
-            className="px-6 py-3 bg-blue-600 text-white rounded"
-          >
-            Notify me
-          </button>
-        </form>
-      </section>
-
-      <footer className="p-4 text-center mt-auto">
-        <a
-          href="mailto:info@falconsystems.ai"
-          className="text-blue-600 dark:text-blue-400 transition-colors duration-300 hover:text-blue-800 dark:hover:text-blue-200"
-        >
-          info@falconsystems.ai
-        </a>
-      </footer>
-    </div>
+    </main>
   );
 }
-

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,19 +1,6 @@
 import React from "react";
 import { App } from "./App";
-import { LeapsPicker } from "./LeapsPicker";
-import { TempovorePage } from "./TempovorePage";
-import { normalizePath } from "./utils";
 
-export function resolvePage(pathname: string) {
-  const path = normalizePath(pathname);
-
-  if (path === "/leapspicker") {
-    return <LeapsPicker />;
-  }
-
-  if (path === "/tempovore") {
-    return <TempovorePage />;
-  }
-
+export function resolvePage(_pathname: string) {
   return <App />;
 }

--- a/src/shell.tsx
+++ b/src/shell.tsx
@@ -6,11 +6,11 @@ export function Html({ children }: PropsWithChildren) {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Falcon Systems – Teaming with AI</title>
+        <title>Falcon Systems – AI Multifamily Deal Intelligence</title>
         <link rel="stylesheet" href="/assets/client.css" />
         <link rel="icon" type="image/png" href="/dist/assets/Falcon-Logo.png" />
       </head>
-      <body className="min-h-screen bg-gradient-to-b from-white to-slate-50 text-slate-900">
+      <body style={{ margin: 0, background: "#020617", color: "#e2e8f0" }}>
         <div id="root">{children}</div>
         <script type="module" src="/assets/client.js"></script>
       </body>


### PR DESCRIPTION
### Motivation
- Pivot the UI toward a concise AI-driven multifamily deal intelligence landing experience and simplify the client surface. 
- Remove legacy/unused interactive pieces and dark-mode toggle to reduce complexity and better present product messaging. 
- Consolidate routing so the site consistently serves the new landing experience. 
- Update HTML shell metadata and global body styling to match the new brand focus. 

### Description
- Reworked `App.tsx` to replace Tailwind-based layout and dark-mode state with an inline-styled landing page, added `dealSignals` and `userOutputs` arrays, and removed the `LeapsPicker` import and the email form handler. 
- Introduced reusable inline style objects (`pageStyle`, `containerStyle`, `cardStyle`) and rebuilt header, feature, and CTA sections with static content and a mailto `Request Early Access` link. 
- Simplified routing in `routes.tsx` by removing `LeapsPicker` and `TempovorePage` resolution and updating `resolvePage` to always return `App`. 
- Updated `Html` in `shell.tsx` to change the page `<title>` and switch the `<body>` to inline dark background and text color styling. 

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ed393c6e2883289a617ce9b81d3eaa)